### PR TITLE
The only way I get wiredep running on my system.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -164,9 +164,6 @@ module.exports = function (grunt) {
 
     // Automatically inject Bower components into the app
     wiredep: {
-      options: {
-        cwd: '<%= yeoman.app %>'
-      },
       app: {
         src: ['<%= yeoman.app %>/index.html'],
         ignorePath:  /\.\.\//


### PR DESCRIPTION
Tim,

I was trying out your app, and this is the only way I could build using grunt,
The cwd option causes on my system wiredep to look or the bower files in the app directory instead of the root.
I think this is because `npm install` selected for me version 2.0.0 of `grunt-wiredep`.  While `package.json` specifies `^1.7.0`.  My guess is that you will probably see it too when you run npm update.

Nice work,


   Steven

P.S: I am doing this in English as most of the developer stuff is, otherwise I would have done it in Dutch.